### PR TITLE
修复节点拥有无效渲染组件时拖拽异常的问题

### DIFF
--- a/packages/gizmo/src/Group.ts
+++ b/packages/gizmo/src/Group.ts
@@ -338,6 +338,9 @@ export class Group {
         }
       }
     }
+    if (tempBoundBox.getExtent(out).length() <= 0) {
+      isEffective = false;
+    }
     if (isEffective) {
       tempBoundBox.getCenter(out);
     } else {


### PR DESCRIPTION
复现路径：
为节点添加 Renderer 但是不设置网格信息，并且锚点模式为 center，此时拖拽 Gizmo 会有问题

修复办法：
判断 Renderer 包围盒的合法性，在无法正常渲染时，Renderer 返回的包围盒 min 与 max 都为 (0,0,0)，应为无效信息。