### PR TITLE
Fix: onLateUpdate for drawing wireframe 

### DIFF
--- a/packages/auxiliary-lines/src/WireframeManager.ts
+++ b/packages/auxiliary-lines/src/WireframeManager.ts
@@ -459,7 +459,7 @@ export class WireframeManager extends Script {
     this._renderer.enabled = false;
   }
 
-  override onUpdate(deltaTime: number): void {
+  override onLateUpdate(deltaTime: number): void {
     const {
       _mesh: mesh,
       _localPositions: localPositions,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
by using onLateUpdate for drawing wireframe to avoid conflict of .clear() and .draw() order 