### PR TITLE
feat: add `easy-animation`

### DIFF
--- a/packages/easy-animation/README.md
+++ b/packages/easy-animation/README.md
@@ -1,0 +1,53 @@
+# Easy Animation
+
+`easy-animation` tool simplifies the playback of model animations by creating multiple animation layers, allowing multiple animations to be played on the same Animator. It also provides the capability to play choreographed animations within a single layer.
+
+## npm
+
+The `easy-animation` is published on npm with full typing support. To install, use:
+
+```sh
+npm install @galacean/engine-toolkit-easy-animation
+```
+```javascript
+import { addAnimatorLayer, multiAnimationsTransition } from "@galacean/engine-toolkit-easy-animation";
+```
+
+## Usage
+
+```javascript
+import { addAnimatorLayer, multiAnimationsTransition } from "@alipay/galacean-toolkit-controls";
+import { GLTFResource, WebGLEngine } from "@galacean/engine";
+import { shuffle } from "lodash";
+
+WebGLEngine.create({ canvas: "canvas" }).then((engine) => {
+  engine.canvas.resizeByClientSize();
+
+  const rootEntity = engine.sceneManager.activeScene.createRootEntity();
+
+  engine.resourceManager
+    .load<GLTFResource>(
+      "*.gltf"
+    )
+    .then((gltf) => {
+      rootEntity.addChild(gltf.defaultSceneRoot);
+    });
+
+  engine.run();
+
+  const { animator, animationNames } = addAnimatorLayer(gltf.defaultSceneRoot);
+  animationNames.forEach((name, idx) => {
+    animator.play(name, idx);
+  });
+
+  multiAnimationsTransition({ animator, transitions: shuffle(animations), layerIndex: 0 });
+});
+```
+
+## Links
+
+- [Repository](https://github.com/galacean/runtime-toolkit)
+
+## License
+
+The engine is released under the [MIT](https://opensource.org/licenses/MIT) license. See LICENSE file.

--- a/packages/easy-animation/package.json
+++ b/packages/easy-animation/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@galacean/engine-toolkit-easy-animation",
+  "version": "1.0.1",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "homepage": "https://oasisengine.cn/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/galacean/engine-toolkit"
+  },
+  "bugs": "https://github.com/galacean/engine-toolkit/issues",
+  "license": "MIT",
+  "scripts": {
+    "b:types": "tsc",
+    "lint:fix": "tslint --fix --project ./tsconfig.json"
+  },
+  "types": "types/index.d.ts",
+  "main": "dist/umd/browser.js",
+  "module": "dist/es/index.js",
+  "files": [
+    "dist/**/*",
+    "types/**/*"
+  ],
+  "peerDependencies": {
+    "@galacean/engine": "^1.0.0-beta21"
+  }
+}

--- a/packages/easy-animation/src/easy-animator.ts
+++ b/packages/easy-animation/src/easy-animator.ts
@@ -1,0 +1,98 @@
+import {
+  AnimationClip,
+  Animator,
+  AnimatorControllerLayer,
+  AnimatorLayerBlendingMode,
+  AnimatorStateMachine,
+  AnimatorStateTransition,
+  Entity
+} from "@galacean/engine";
+
+function getAnimations(model: Entity, layer = 0) {
+  const clips: AnimationClip[] = [];
+  const animator = model.getComponent(Animator);
+  if (!animator) return clips;
+  const animatorController = animator.animatorController.layers[layer];
+  animatorController.stateMachine.states.forEach((state) => {
+    clips.push(state.clip);
+  });
+  return clips;
+}
+
+/**
+ * 在播放动画模型实体的动画组件上加多层 layer
+ *
+ * 目前有多少个动画就有多少个 layer
+ * @param model 要播放动画的模型实体
+ * @param blendingMode 混合模式，默认覆盖模式
+ * @returns animator 动画组件
+ * @returns animationNames 模型上所有的动画名
+ */
+export function addAnimatorLayer(model: Entity, blendingMode = AnimatorLayerBlendingMode.Override) {
+  const animator = model.getComponent(Animator);
+  if (!animator) {
+    console.warn("easy-animator: 模型没有动画组件");
+    return;
+  }
+
+  const animations = getAnimations(model);
+  const animationNames = animations.map((clip, index) => {
+    const animatorStateMachine = new AnimatorStateMachine();
+    const newState = animatorStateMachine.addState(clip.name);
+    newState.clip = clip;
+    const additiveLayer = new AnimatorControllerLayer(`additiveLayer-${index}`);
+    additiveLayer.stateMachine = animatorStateMachine;
+    additiveLayer.blendingMode = blendingMode;
+    animator.animatorController.addLayer(additiveLayer);
+
+    return clip.name;
+  });
+
+  return { animator, animationNames };
+}
+
+/**
+ * 同一个 layer 上的多个动画连续播放
+ * @param animator 播放动画组件实例
+ * @param transitions 动画播放顺序数组
+ * @param layerIndex 动画 layer 层级
+ */
+export function multiAnimationsTransition({
+  animator,
+  transitions,
+  layerIndex
+}: {
+  animator: Animator;
+  transitions: string[];
+  layerIndex: number;
+}) {
+  if (!transitions.length) {
+    console.warn("easy-animator: transitions 为空数组");
+    return;
+  }
+
+  const layer = animator.animatorController.layers[layerIndex];
+  const { stateMachine } = layer;
+
+  const states = transitions.map((name, index) => {
+    const aniName = `${name}-${index}`;
+    const state = stateMachine.addState(aniName);
+    state.clip = animator.findAnimatorState(name).clip;
+
+    return {
+      name: aniName,
+      state,
+      transition: new AnimatorStateTransition()
+    };
+  });
+
+  for (let i = 0, len = states.length; i < len; i++) {
+    states[i].transition.duration = 0;
+    states[i].transition.offset = 0;
+    states[i].transition.exitTime = 1;
+    states[i].transition.destinationState = i === len - 1 ? states[0].state : states[i + 1].state;
+    states[i].state.addTransition(states[i].transition);
+  }
+
+  animator.play(states[0].name, layerIndex);
+}

--- a/packages/easy-animation/src/index.ts
+++ b/packages/easy-animation/src/index.ts
@@ -1,0 +1,1 @@
+export { addAnimatorLayer, multiAnimationsTransition } from "./easy-animator";

--- a/packages/easy-animation/tsconfig.json
+++ b/packages/easy-animation/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "esnext",
+    "declaration": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "declarationDir": "types",
+    "emitDeclarationOnly": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "noImplicitOverride": true,
+    "incremental": false
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/galacean/engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
`easy-animation` simplifies the playback of model animations by creating multiple animation layers, allowing multiple animations to be played on the same Animator easily. It also provides the capability to play choreographed animations within a single layer.
### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior (if this is a feature change)?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information: