### PR TITLE
Fix: disable and enable Stats

### DIFF
--- a/packages/stats/src/Stats.ts
+++ b/packages/stats/src/Stats.ts
@@ -7,24 +7,34 @@ import Monitor from "./Monitor";
  */
 export class Stats extends Script {
   private monitor: Monitor;
+  private camera: Camera;
 
   static hookRequest() {
     hookRequest();
   }
 
+  override set enabled(value: boolean) {
+    value ? this._setupMonitor() : this.monitor.destroy();
+  }
+
   override onBeginRender(camera: Camera): void {
+    this.camera = camera;
     if (!this.monitor) {
-      // @ts-ignore
-      const gl = camera.engine._hardwareRenderer.gl;
-      if (gl) {
-        this.monitor = new Monitor(gl);
-      }
+      this._setupMonitor();
     }
   }
 
   override onEndRender(camera: Camera): void {
     if (this.monitor) {
       this.monitor.update();
+    }
+  }
+
+  private _setupMonitor() {
+    // @ts-ignore
+    const gl = this.camera.engine._hardwareRenderer.gl;
+    if (gl) {
+      this.monitor = new Monitor(gl);
     }
   }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Fix the bug that the stats won't be removed after disable this component. 