### PR TITLE
Fix: trigger gizmo only when down

### DIFF
--- a/packages/gizmo/src/Gizmo.ts
+++ b/packages/gizmo/src/Gizmo.ts
@@ -156,8 +156,8 @@ export class Gizmo extends Script {
     if (!this._initialized) {
       return;
     }
-
-    const { pointers } = this.engine.inputManager;
+    const { inputManager } = this.engine;
+    const { pointers } = inputManager;
     const pointer = pointers.find((pointer: Pointer) => {
       return pointer.phase !== PointerPhase.Up && pointer.phase !== PointerPhase.Leave;
     });
@@ -217,7 +217,7 @@ export class Gizmo extends Script {
         if (x <= 0 || y <= 0 || x > canvas.width || y > canvas.height) {
           return;
         }
-        if ((pointer.pressedButtons & PointerButton.Primary) !== 0) {
+        if (inputManager.isPointerDown(PointerButton.Primary)) {
           this._framebufferPicker.pick(pointer.position.x, pointer.position.y).then((result) => {
             if (result) {
               this._selectHandler(result, pointer.position);


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
gizmo should only be triggered if pointer is down, not held down