### PR TITLE
Fix: avoid infinity bounds in gizmo

### DIFF
--- a/packages/gizmo/src/Group.ts
+++ b/packages/gizmo/src/Group.ts
@@ -334,24 +334,13 @@ export class Group {
       for (let j = renderers.length - 1; j >= 0; j--) {
         const renderer = renderers[j];
         if (renderer.entity.isActiveInHierarchy) {
-          const bounds = renderers[j].bounds;
-          const isBoundsInfinity =
-            bounds.max.x >= Number.MAX_VALUE &&
-            bounds.max.y >= Number.MAX_VALUE &&
-            bounds.max.z >= Number.MAX_VALUE &&
-            bounds.min.x <= -Number.MAX_VALUE &&
-            bounds.min.y <= -Number.MAX_VALUE &&
-            bounds.min.z <= -Number.MAX_VALUE;
-          if (isBoundsInfinity) {
-            isEffective = false;
-            break;
-          }
-
-          BoundingBox.merge(tempBoundBox, bounds, tempBoundBox);
+          BoundingBox.merge(tempBoundBox, renderers[j].bounds, tempBoundBox);
         }
       }
     }
-    if (tempBoundBox.getExtent(out).length() <= 0) {
+
+    const length = tempBoundBox.getExtent(out).length();
+    if (length <= 0 || length >= Number.MAX_VALUE) {
       isEffective = false;
     }
     if (isEffective) {

--- a/packages/gizmo/src/Group.ts
+++ b/packages/gizmo/src/Group.ts
@@ -334,7 +334,20 @@ export class Group {
       for (let j = renderers.length - 1; j >= 0; j--) {
         const renderer = renderers[j];
         if (renderer.entity.isActiveInHierarchy) {
-          BoundingBox.merge(tempBoundBox, renderers[j].bounds, tempBoundBox);
+          const bounds = renderers[j].bounds;
+          const isBoundsInfinity =
+            bounds.max.x >= Number.MAX_VALUE &&
+            bounds.max.y >= Number.MAX_VALUE &&
+            bounds.max.z >= Number.MAX_VALUE &&
+            bounds.min.x <= -Number.MAX_VALUE &&
+            bounds.min.y <= -Number.MAX_VALUE &&
+            bounds.min.z <= -Number.MAX_VALUE;
+          if (isBoundsInfinity) {
+            isEffective = false;
+            break;
+          }
+
+          BoundingBox.merge(tempBoundBox, bounds, tempBoundBox);
         }
       }
     }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/galacean/engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
when renderer has infinity bounds, for example ParticleRenderer in 1.2.0.-alpha.14, the center mode for anchor should be ineffective